### PR TITLE
v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 https://github.com/JustinFreitas/MountTracker
 
-MountTracker v1.3, by Justin Freitas
+MountTracker v1.3.1, by Justin Freitas
 
 ReadMe and Usage Notes
 
@@ -73,3 +73,4 @@ Changelist:
 - v1.1 - Changed the in-combat firing of the stealth functionality fromn onTurnStart to requestActivation.  Now, it works when you click the left CT bar to activate an actor that way (and still works when using the Next Actor button too).  Migrated over the build tool for consistency in building the extension output.
 - v1.2 - Updated the icon using Sir Motte's template.  Don't use crossed eye icon in chat messages.
 - v1.3 - Another icon update, this time 42px to conform to new theme style.
+- v1.3.1 - Don't display MountTracker information to the players if the rider is an NPC and not a friend.  This will be enforced even if Show to Players is enabled in the options.

--- a/extension.xml
+++ b/extension.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <root version="3.3" release="8.1|CoreRPG:4.1">
-	<announcement text="MountTracker v1.3 FGC/FGU 5E, 7/4/23\r2021-2023 Justin Freitas" font="emotefont" icon="mount_icon" />
+	<announcement text="MountTracker v1.3.1 FGC/FGU 5E, 9/9/23\r2021-2023 Justin Freitas" font="emotefont" icon="mount_icon" />
 	<properties>
 		<name>Feature: MountTracker</name>
-		<version>1.3</version>
+		<version>1.3.1</version>
 		<loadorder>9990</loadorder>
 		<author>Justin Freitas</author>
 		<description>Tracks the mount state of a CT actor with a specific effect and some appropriate chat text information regarding rules around some actions.</description>


### PR DESCRIPTION
Don't display MountTracker information to the players if the rider is an NPC and not a friend.  This will be enforced even if Show to Players is enabled in the options.